### PR TITLE
Correct style for pokedetail container

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -127,7 +127,7 @@ body{
 
 .pokedetail{
   width: 50%;
-  height: calc(90vh - 30px);
+  min-height: calc(90vh - 30px);
   padding: 10px;
   margin: 10px;
   text-align: center;


### PR DESCRIPTION
# What?
Correct the height attribute for the *pokedetail* container in the *single-detail-pokemon* view.